### PR TITLE
fix: :bug: Add script to bin folder

### DIFF
--- a/bin/session-maker-for-spotify
+++ b/bin/session-maker-for-spotify
@@ -5,5 +5,5 @@ if [[ -L "$SCRIPT" ]]; then
     SCRIPT="$(readlink "$SCRIPT")"
 fi
 
-ROOTDIR="$(cd "$(dirname $0)/.." && pwd)"
+ROOTDIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
 node "${ROOTDIR}/index.js" "$@"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "session-maker-for-spotify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create Spotify sessions using multiple playlists",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
+  },
+  "bin": {
+    "session-maker-for-spotify": "bin/session-maker-for-spotify"
   },
   "keywords": [
     "spotify",


### PR DESCRIPTION
Currently, when installing session-maker-for-spotify globally using npm, the main script is not added to proper bin folder. This PR adds its support.

Fixes https://github.com/javsalgar/session-maker-for-spotify/issues/1

Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>